### PR TITLE
feat: Make theme fonts and colors customizable

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -58,6 +58,40 @@
 		{{/if}}
 	{{/match}}
 
+	<style>
+		:root {
+			{{#if @custom.body_font}}--gh-font-body: '{{@custom.body_font}}', sans-serif;{{/if}}
+			{{#if @custom.heading_font}}--gh-font-heading: '{{@custom.heading_font}}', sans-serif;{{/if}}
+
+			{{#if @custom.light_background_main}}--color-background-main: {{@custom.light_background_main}};{{/if}}
+			{{#if @custom.light_background_secondary}}--color-background-secondary: {{@custom.light_background_secondary}};{{/if}}
+			{{#if @custom.light_background_contrast}}--color-background-contrast: {{@custom.light_background_contrast}};{{/if}}
+			{{#if @custom.light_content_lead}}--color-content-lead: {{@custom.light_content_lead}};{{/if}}
+			{{#if @custom.light_content_main}}--color-content-main: {{@custom.light_content_main}};{{/if}}
+			{{#if @custom.light_content_secondary}}--color-content-secondary: {{@custom.light_content_secondary}};{{/if}}
+		}
+
+		.theme-dark:root {
+			{{#if @custom.dark_background_main}}--color-background-main: {{@custom.dark_background_main}};{{/if}}
+			{{#if @custom.dark_background_secondary}}--color-background-secondary: {{@custom.dark_background_secondary}};{{/if}}
+			{{#if @custom.dark_background_contrast}}--color-background-contrast: {{@custom.dark_background_contrast}};{{/if}}
+			{{#if @custom.dark_content_lead}}--color-content-lead: {{@custom.dark_content_lead}};{{/if}}
+			{{#if @custom.dark_content_main}}--color-content-main: {{@custom.dark_content_main}};{{/if}}
+			{{#if @custom.dark_content_secondary}}--color-content-secondary: {{@custom.dark_content_secondary}};{{/if}}
+		}
+
+		@media (prefers-color-scheme: dark) {
+			html:not(.theme-light):root {
+				{{#if @custom.dark_background_main}}--color-background-main: {{@custom.dark_background_main}};{{/if}}
+				{{#if @custom.dark_background_secondary}}--color-background-secondary: {{@custom.dark_background_secondary}};{{/if}}
+				{{#if @custom.dark_background_contrast}}--color-background-contrast: {{@custom.dark_background_contrast}};{{/if}}
+				{{#if @custom.dark_content_lead}}--color-content-lead: {{@custom.dark_content_lead}};{{/if}}
+				{{#if @custom.dark_content_main}}--color-content-main: {{@custom.dark_content_main}};{{/if}}
+				{{#if @custom.dark_content_secondary}}--color-content-secondary: {{@custom.dark_content_secondary}};{{/if}}
+			}
+		}
+	</style>
+
 	{{ghost_head}}
 </head>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "attila",
-  "version": "3.8.0",
+  "version": "3.9.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "attila",
-      "version": "3.8.0",
+      "version": "3.9.0",
       "license": "MIT",
       "dependencies": {
         "sass": "^1.89.2"

--- a/package.json
+++ b/package.json
@@ -88,6 +88,86 @@
         ],
         "default": "Default",
         "group": "post"
+      },
+      "body_font": {
+        "type": "select",
+        "options": [
+          "Inter",
+          "Roboto",
+          "Lato"
+        ],
+        "default": "Inter",
+        "group": "typography"
+      },
+      "heading_font": {
+        "type": "select",
+        "options": [
+          "Inter",
+          "Roboto",
+          "Lato"
+        ],
+        "default": "Inter",
+        "group": "typography"
+      },
+      "light_background_main": {
+        "type": "color",
+        "default": "#FFFFFF",
+        "group": "colors"
+      },
+      "light_background_secondary": {
+        "type": "color",
+        "default": "#F7F8FA",
+        "group": "colors"
+      },
+      "light_background_contrast": {
+        "type": "color",
+        "default": "#E1E3E6",
+        "group": "colors"
+      },
+      "light_content_lead": {
+        "type": "color",
+        "default": "#000000",
+        "group": "colors"
+      },
+      "light_content_main": {
+        "type": "color",
+        "default": "#222426",
+        "group": "colors"
+      },
+      "light_content_secondary": {
+        "type": "color",
+        "default": "#73777D",
+        "group": "colors"
+      },
+      "dark_background_main": {
+        "type": "color",
+        "default": "#222426",
+        "group": "colors"
+      },
+      "dark_background_secondary": {
+        "type": "color",
+        "default": "#1D1F20",
+        "group": "colors"
+      },
+      "dark_background_contrast": {
+        "type": "color",
+        "default": "#3B3D40",
+        "group": "colors"
+      },
+      "dark_content_lead": {
+        "type": "color",
+        "default": "#FFFFFF",
+        "group": "colors"
+      },
+      "dark_content_main": {
+        "type": "color",
+        "default": "#E1E3E6",
+        "group": "colors"
+      },
+      "dark_content_secondary": {
+        "type": "color",
+        "default": "#909499",
+        "group": "colors"
       }
     }
   },


### PR DESCRIPTION
This commit introduces new theme options to allow site administrators to select custom fonts and colors directly from the Ghost admin panel.

The following changes have been made:
- Added `select` options in `package.json` for choosing body and heading fonts.
- Added a full set of `color` pickers in `package.json` for all key theme colors, for both light and dark modes.
- Updated `default.hbs` to apply the selected fonts and colors by overriding the default CSS variables.
- The new settings are grouped under `typography` and `colors` in the theme options for better organization.